### PR TITLE
Potential fix for code scanning alert no. 1: Shell command built from environment values

### DIFF
--- a/scripts/compile-date-locales.js
+++ b/scripts/compile-date-locales.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 const util = require('util')
-const exec = util.promisify(require('child_process').exec)
+const execFile = util.promisify(require('child_process').execFile)
 const path = require('path')
 const fs = require('fs')
 
@@ -14,7 +14,7 @@ async function compile(entry) {
   const locale = entry.name
   const module = path.join(source, locale, 'index.js')
   try {
-    const { stderr } = await exec(`npx rollup ${module} -c ${rollupConf} --file ${destDir}/${locale}.js`)
+    const { stderr } = await execFile('npx', ['rollup', module, '-c', rollupConf, '--file', `${destDir}/${locale}.js`])
     console.log(stderr)
   } catch (err) {
     if (err) {


### PR DESCRIPTION
Potential fix for [https://github.com/pwnautopilots/lichobile/security/code-scanning/1](https://github.com/pwnautopilots/lichobile/security/code-scanning/1)

To fix the problem, we should avoid constructing the shell command as a single string and instead use the `execFile` function from the `child_process` module. This function allows us to pass the command and its arguments separately, which prevents the shell from interpreting special characters in the paths.

- Replace the `exec` function call with `execFile` to separate the command and its arguments.
- Update the import to use `execFile` instead of `exec`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
